### PR TITLE
Userless Access & Added Venue Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,17 @@ foursquare client into your project.
 ### Instantiate the API Gateway Factory
 
       $factory = new \TheTwelve\Foursquare\ApiGatewayFactory($client);
+      
+      // Required for most requests
+      $factory->setClientCredentials('CLIENT_ID', 'CLIENT_SECRET');
+
+      // Optional
       $factory->setEndpointUri('https://api.foursquare.com');
       $factory->useVersion(2);
 
 ### Begin authentication with Foursquare
 
       $auth = $factory->getAuthenticationGateway(
-          'YOUR_CLIENT_ID',
-          'YOUR_CLIENT_SECRET',
           'https://foursquare.com/oauth2/authorize',
           'https://foursquare.com/oauth2/access_token',
           'YOUR_REDIRECT_URL'
@@ -53,8 +56,9 @@ foursquare client into your project.
 
 ### Foursquare redirects the user back to you after a successful login
 
-      $code = $_GET['code']; 
-      // you should do some input sanitization to $code here, just in case 
+      $code = $_GET['code'];
+
+      // You should do some input sanitization to $code here, just in case 
       $token = $authGateway->authenticateUser($code);
 
 ### Update the API Gateway Factory with your OAuth token
@@ -68,3 +72,14 @@ foursquare client into your project.
 ### Get data from Foursquare
 
       $user = $gateway->getUser();
+
+### Search venues
+
+      $gateway = $factory->getVenuesGateway();
+
+      $venues = $gateway->search(array(
+        'll' => '40.727198,-73.992289',
+        'query' => 'Starbucks',
+        'radius' => 1000,
+        'intent' => 'checkin'
+      ));

--- a/lib/TheTwelve/Foursquare/ApiGatewayFactory.php
+++ b/lib/TheTwelve/Foursquare/ApiGatewayFactory.php
@@ -6,13 +6,13 @@ class ApiGatewayFactory
 {
 
     /** @var \TheTwelve\Foursquare\HttpClient */
-    protected $client;
+    protected $httpClient;
 
     /** @var string */
-    protected $version;
+    protected $version = 'v2';
 
     /** @var string */
-    protected $endpointUri;
+    protected $endpointUri = 'https://api.foursquare.com';
 
     /** @var string */
     protected $token;
@@ -22,12 +22,12 @@ class ApiGatewayFactory
 
     /**
      * initialize the gateway
-     * @param \TheTwelve\Foursquare\HttpClient $client
+     * @param \TheTwelve\Foursquare\HttpClient $httpClient
      */
-    public function __construct(HttpClient $client)
+    public function __construct(HttpClient $httpClient)
     {
 
-        $this->client = $client;
+        $this->httpClient = $httpClient;
 
     }
 
@@ -40,6 +40,21 @@ class ApiGatewayFactory
     {
 
         $this->version = 'v' . $version;
+        return $this;
+
+    }
+
+    /**
+     * set the api endpoint uri
+     * @param string $id
+     * @param string $secret
+     * @return \TheTwelve\Foursquare\ApiGatewayFactory
+     */
+    public function setClientCredentials($id, $secret)
+    {
+
+        $this->clientId = $id;
+        $this->clientSecret = $secret;
         return $this;
 
     }
@@ -72,20 +87,17 @@ class ApiGatewayFactory
 
     /**
      * factory method for authentication gateway
-     * @param string $id
-     * @param string $secret
      * @param string $authorizeUri
      * @param string $accessTokenUri
      * @param string $redirectUri
      * @return \TheTwelve\Foursquare\AuthenticationGateway
      */
     public function getAuthenticationGateway(
-        $id, $secret, $authorizeUri, $accessTokenUri, $redirectUri
+        $authorizeUri, $accessTokenUri, $redirectUri
     ) {
 
-        $gateway = new AuthenticationGateway($this->client, $this);
-        $gateway->setAuthorizationParams($id, $secret)
-                ->setAuthorizeUri($authorizeUri)
+        $gateway = new AuthenticationGateway($this->httpClient);
+        $gateway->setAuthorizeUri($authorizeUri)
                 ->setAccessTokenUri($accessTokenUri)
                 ->setRedirectUri($redirectUri);
 
@@ -101,7 +113,7 @@ class ApiGatewayFactory
     public function getUsersGateway($userId = null)
     {
 
-        $gateway = new UsersGateway($this->client);
+        $gateway = new UsersGateway($this->httpClient);
 
         if (!is_null($userId)) {
             $gateway->setUserId($userId);
@@ -114,12 +126,13 @@ class ApiGatewayFactory
 
     /**
      * factory method for venues gateway
+     * @param string $id
+     * @param string $secret
      * @return \TheTwelve\Foursquare\VenuesGateway
      */
     public function getVenuesGateway()
     {
-
-        $gateway = new VenuesGateway($this->client);
+        $gateway = new VenuesGateway($this->httpClient);
         $this->injectGatewayDependencies($gateway);
         return $gateway;
 
@@ -132,7 +145,7 @@ class ApiGatewayFactory
     public function getVenueGroupsGateway()
     {
 
-        $gateway = new VenueGroupsGateway($this->client);
+        $gateway = new VenueGroupsGateway($this->httpClient);
         $this->injectGatewayDependencies($gateway);
         return $gateway;
 
@@ -160,7 +173,8 @@ class ApiGatewayFactory
     {
 
         $gateway->setRequestUri($this->getRequestUri())
-                ->setToken($this->token);
+                ->setToken($this->token)
+                ->setClientCredentials($this->clientId, $this->clientSecret);
 
     }
 

--- a/lib/TheTwelve/Foursquare/AuthenticationGateway.php
+++ b/lib/TheTwelve/Foursquare/AuthenticationGateway.php
@@ -21,21 +21,6 @@ class AuthenticationGateway extends EndpointGateway
     protected $redirectUri;
 
     /**
-     * set authentication params
-     * @param string $id
-     * @param string $secret
-     * @return \TheTwelve\Foursquare\AuthenticationGateway
-     */
-    public function setAuthorizationParams($id, $secret)
-    {
-
-        $this->id = $id;
-        $this->secret = $secret;
-        return $this;
-
-    }
-
-    /**
      * set the authentication uri
      * @param string $uri
      * @return \TheTwelve\Foursquare\AuthenticationGateway
@@ -96,7 +81,7 @@ class AuthenticationGateway extends EndpointGateway
         );
 
         $uri = $this->authorizeUri . '?' . http_build_query($uriParams);
-        return $this->client->redirect($uri);
+        return $this->httpClient->redirect($uri);
 
     }
 
@@ -121,15 +106,14 @@ class AuthenticationGateway extends EndpointGateway
             throw new \InvalidArgumentException('Foursquare code is invalid');
         }
 
-        $uriParams = array(
+        $response = json_decode($this->httpClient->get($this->accessTokenUri, array(
             'client_id' => $this->id,
             'client_secret' => $this->secret,
             'grant_type' => 'authorization_code',
             'redirect_uri' => $this->redirectUri,
             'code' => $code,
-        );
+        )));
 
-        $response = json_decode($this->client->get($this->accessTokenUri, $uriParams));
         $this->token = isset($response->access_token)
             ? $response->access_token : null;
 
@@ -143,9 +127,7 @@ class AuthenticationGateway extends EndpointGateway
      */
     protected function canInitiateLogin()
     {
-
         return $this->id && $this->redirectUri && $this->authorizeUri;
-
     }
 
     /**
@@ -154,10 +136,8 @@ class AuthenticationGateway extends EndpointGateway
      */
     protected function canAuthenticateUser()
     {
-
         return $this->id && $this->secret
             && $this->redirectUri && $this->accessTokenUri;
-
     }
 
     /**
@@ -167,9 +147,7 @@ class AuthenticationGateway extends EndpointGateway
      */
     protected function codeIsValid($code)
     {
-
         return !is_null($code);
-
     }
 
 }

--- a/lib/TheTwelve/Foursquare/VenuesGateway.php
+++ b/lib/TheTwelve/Foursquare/VenuesGateway.php
@@ -4,20 +4,17 @@ namespace TheTwelve\Foursquare;
 
 class VenuesGateway extends EndpointGateway
 {
-
     /**
      * Enter description here ...
      * @param string $venueId
-     * @return \stdClass
+     * @return object
      */
     public function getVenue($venueId)
     {
-
         $resource = '/venues/' . $venueId;
         $response = $this->makeApiRequest($resource);
 
         return $response->venue;
-
     }
 
     public function add()
@@ -34,12 +31,10 @@ class VenuesGateway extends EndpointGateway
      */
     public function categories()
     {
-
         $resource = '/venues/categories';
         $response = $this->makeApiRequest($resource);
 
         return $response->categories;
-
     }
 
     public function explore()
@@ -51,16 +46,25 @@ class VenuesGateway extends EndpointGateway
      */
     public function managed()
     {
-
         $resource = '/venues/managed';
         $response = $this->makeApiRequest($resource);
 
         return $response->venues;
-
     }
+    
+    /**
+     * Returns a list of venues near the current location, optionally matching a search term.
+     * @see https://developer.foursquare.com/docs/venues/search
+     * @param array $params
+     * @return array
+     */
+    public function search(array $params = array())
+    {
+        $resource = '/venues/search';
+        $response = $this->makeApiRequest($resource, $params);
 
-    public function search()
-    {}
+        return $response->venues;
+    }
 
     public function suggestCompletion()
     {}

--- a/tests/lib/TheTwelve/Foursquare/ApiGatewayFactoryTest.php
+++ b/tests/lib/TheTwelve/Foursquare/ApiGatewayFactoryTest.php
@@ -17,7 +17,7 @@ class TheTwelve_Foursquare_ApiGatewayFactoryTest
 
         $factory = $this->createFactory($client, $token);
 
-        $this->assertAttributeEquals($client, 'client', $factory);
+        $this->assertAttributeEquals($client, 'httpClient', $factory);
         $this->assertAttributeEquals($version, 'version', $factory);
         $this->assertAttributeEquals($_GET['endpointUri'], 'endpointUri', $factory);
         $this->assertAttributeEquals($token, 'token', $factory);
@@ -37,9 +37,10 @@ class TheTwelve_Foursquare_ApiGatewayFactoryTest
 
         $factory = $this->createFactory($client);
 
+        $factory->setClientCredentials($_GET['clientId'], $_GET['clientSecret']);
+
         $gateway = $factory->getAuthenticationGateway(
-            $_GET['clientId'],
-            $_GET['clientSecret'],
+            
             $_GET['authorizeUri'],
             $_GET['accessTokenUri'],
             $_GET['redirectUri']
@@ -54,7 +55,7 @@ class TheTwelve_Foursquare_ApiGatewayFactoryTest
         $this->assertAttributeEquals($_GET['accessTokenUri'], 'accessTokenUri', $gateway);
         $this->assertAttributeEquals($_GET['redirectUri'], 'redirectUri', $gateway);
 
-        $this->assertAttributeEquals($client, 'client', $gateway);
+        $this->assertAttributeEquals($client, 'httpClient', $gateway);
         $this->assertAttributeEquals(null, 'token', $gateway);
         $this->assertAttributeEquals(null, 'requestUri', $gateway);
 


### PR DESCRIPTION
Adding Venue Search came at a price, as Userless access was currently not possible with this client library. Now you can provide a client ID and client secret and have it use those tokens if no access token is provided. This was required for search and I believe is required for most of the API now.
