### PR TITLE
If search doesn't return results, return empty array

### DIFF
--- a/lib/TheTwelve/Foursquare/VenuesGateway.php
+++ b/lib/TheTwelve/Foursquare/VenuesGateway.php
@@ -49,7 +49,11 @@ class VenuesGateway extends EndpointGateway
         $resource = '/venues/managed';
         $response = $this->makeApiRequest($resource);
 
-        return $response->venues;
+        if(property_exists($response, 'venues')) {
+            return $response->venues;
+        }
+        
+        return array();
     }
     
     /**

--- a/lib/TheTwelve/Foursquare/VenuesGateway.php
+++ b/lib/TheTwelve/Foursquare/VenuesGateway.php
@@ -67,7 +67,11 @@ class VenuesGateway extends EndpointGateway
         $resource = '/venues/search';
         $response = $this->makeApiRequest($resource, $params);
 
-        return $response->venues;
+        if(property_exists($response, 'venues')) {
+            return $response->venues;
+        }
+        
+        return array();
     }
 
     public function suggestCompletion()


### PR DESCRIPTION
Currently the VenuesGateway tries to return `$response->venues`, but if search has no results, there's no property _venues_ and throws an ErrorException.
